### PR TITLE
Improve compatibility with find AppIcon

### DIFF
--- a/libs/ipa-manager.js
+++ b/libs/ipa-manager.js
@@ -70,8 +70,8 @@ const add = async (file) => {
   let plistFile, iconFiles = []
 
   // unzip files
-  const newIconRegular = /Payload\/.*\.app\/AppIcon-?(\d+(\.\d+)?)x(\d+(\.\d+)?)(@\dx)?.*\.png$/
-  const oldIconRegular = /Payload\/.*\.app\/Icon-?(\d+(\.\d+)?)?.png$/
+  const newIconRegular = /Payload\/.*\.app\/AppIcon-?[^\d]*(\d+(\.\d+)?)x(\d+(\.\d+)?)(@\dx)?.*\.png$/
+  const oldIconRegular = /Payload\/.*\.app\/Icon-?[^\d]*(\d+(\.\d+)?)?.png$/
   await fs.remove(tmpDir)
   await decompress({
     file: file,

--- a/libs/ipa-manager.js
+++ b/libs/ipa-manager.js
@@ -61,6 +61,8 @@ const decompress = (opt) => new Promise((resolve, reject) => {
 })
 
 const fixPNG = (input, output) => new Promise((resolve, reject) => {
+  input = input.replace(/ /g, "\\ ")                                                       
+  output = output.replace(/ /g, "\\ ")
   pngdefry(input, output, (err) => err ? reject(err) : resolve())
 })
 


### PR DESCRIPTION
1. compatibility with some AppIcon with other string after "AppIcon-", like "AppIcon-TikTok20x20@2x.png";
2. compatibility with some AppName with space like "Google Chrome.app", in this case will cause pngdefry failed with the following error:
````
/tmp/cn.ineva.upload/unzip-tmp/Payload/Quantumult : not found or could not be opened | stdout
X.app/Icon.png : not found or could not be opened | stdout
````