### PR TITLE
Fix password not being passed in correctly

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ if [ -n "$LOGIN_USER" ];then
 fi
 
 if [ -n "$LOGIN_PASS" ];then
-    ipasd_args=$ipasd_args"-user $LOGIN_PASS "
+    ipasd_args=$ipasd_args"-pass $LOGIN_PASS "
 fi
 
 /app/ipasd $ipasd_args


### PR DESCRIPTION
## Problem to fix
When running the container, the `LOGIN_PASS` passed in via ENV is not being passed to `ipasd` correctly.
